### PR TITLE
Update libraries

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/melih/apps/pokeapp/SdkVersions.kt
+++ b/build-logic/convention/src/main/kotlin/com/melih/apps/pokeapp/SdkVersions.kt
@@ -2,6 +2,6 @@ package com.melih.apps.pokeapp
 
 object SdkVersions {
     const val compileSdkVersion: Int = 34
-    const val minSdkVersion: Int = 26
+    const val minSdkVersion: Int = 27
     const val targetSdkVersion: Int = 34
 }

--- a/build-logic/convention/src/main/kotlin/com/melih/apps/pokeapp/SdkVersions.kt
+++ b/build-logic/convention/src/main/kotlin/com/melih/apps/pokeapp/SdkVersions.kt
@@ -1,7 +1,7 @@
 package com.melih.apps.pokeapp
 
 object SdkVersions {
-    const val compileSdkVersion: Int = 33
+    const val compileSdkVersion: Int = 34
     const val minSdkVersion: Int = 26
-    const val targetSdkVersion: Int = 33
+    const val targetSdkVersion: Int = 34
 }

--- a/features/pokemons/impl/src/test/java/com/melih/android/pokeapp/pokemons/impl/data/DefaultPokemonsRepositoryTest.kt
+++ b/features/pokemons/impl/src/test/java/com/melih/android/pokeapp/pokemons/impl/data/DefaultPokemonsRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.melih.android.pokeapp.pokemons.impl.data
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
 import androidx.paging.PagingData
+import androidx.paging.testing.asSnapshot
 import com.melih.android.pokeapp.core.coroutines.test.TestDispatcherExtension
 import com.melih.android.pokeapp.pokemons.impl.data.datasource.PokemonsPagerFactory
 import io.mockk.every
@@ -46,7 +47,7 @@ internal class DefaultPokemonsRepositoryTest {
                 ),
             )
 
-            val items = repository.getPokemons().testPaging(this)
+            val items = repository.getPokemons().asSnapshot()
 
             assertEquals(
                 expected = items,
@@ -72,7 +73,7 @@ internal class DefaultPokemonsRepositoryTest {
                 )
 
                 assertThrows<IOException> {
-                    repository.getPokemons().testPaging(this)
+                    repository.getPokemons().asSnapshot()
                 }
             }
         }

--- a/features/pokemons/impl/src/test/java/com/melih/android/pokeapp/pokemons/impl/data/TestData.kt
+++ b/features/pokemons/impl/src/test/java/com/melih/android/pokeapp/pokemons/impl/data/TestData.kt
@@ -1,12 +1,7 @@
 package com.melih.android.pokeapp.pokemons.impl.data
 
-import androidx.paging.PagingData
 import androidx.paging.PagingSource
-import androidx.paging.testing.SnapshotLoader
-import androidx.paging.testing.asSnapshot
 import com.melih.android.pokeapp.pokemons.api.model.Pokemon
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
 import nl.wykorijnsburger.kminrandom.minRandomCached
 
 val allPokemons = (1..36).map {
@@ -45,8 +40,3 @@ val loadResults = listOf(
         itemsAfter = 0,
     ),
 )
-
-suspend fun Flow<PagingData<Pokemon>>.testPaging(
-    coroutineScope: CoroutineScope,
-    loadOperations: suspend SnapshotLoader<Pokemon>.() -> @JvmSuppressWildcards Unit = {},
-): List<Pokemon> = asSnapshot(coroutineScope, loadOperations = loadOperations)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,29 +1,29 @@
 [versions]
 gradlePlugin = "8.1.1"
 
-androidxComposeBom = "2023.01.00"
-androidxComposeCompiler = "1.4.3"
+androidxComposeBom = "2023.09.00"
+androidxComposeCompiler = "1.5.3"
 
 # todo implement composition tracing https://developer.android.com/jetpack/compose/performance/tracing
 androidxComposeRuntimeTracing = "1.0.0-alpha01"
 
 detektPlugin = '1.23.0'
 
-kotlin = '1.8.10'
+kotlin = '1.9.10'
 kotlinxCoroutines = '1.6.4'
 kotlinxCollectionsImmutable = '0.3.5'
 
-androidxCore = '1.9.0'
-androidxAppCompat = "1.5.1"
-androidxActivityCompose = '1.6.1'
-androidxLifecycle = '2.6.0-alpha03'
-androidxNavigation = '2.5.3'
+androidxCore = '1.12.0'
+androidxAppCompat = "1.6.1"
+androidxActivityCompose = '1.7.2'
+androidxLifecycle = '2.6.2'
+androidxNavigation = '2.7.2'
 androidxHiltNavigation = '1.0.0'
 googleAccompanist = '0.29.0-alpha'
-androidxPaging = '3.2.0-alpha04'
-androidxPagingCompose = '1.0.0-alpha18'
+androidxPaging = '3.2.1'
+androidxPagingCompose = '3.2.1'
 
-dagger = '2.45'
+dagger = '2.47'
 
 retrofit = '2.9.0'
 okhttp = '4.10.0'
@@ -31,17 +31,17 @@ chucker = '3.5.2'
 
 timber = '5.0.1'
 
-androidxEspresso = '3.4.0'
+androidxEspresso = '3.5.1'
 androidxTestCore = "1.5.0"
-androidxTestExt = "1.1.4"
+androidxTestExt = "1.1.5"
 androidxTestRules = "1.5.0"
-androidxTestRunner = "1.5.1"
+androidxTestRunner = "1.5.2"
 androidxUiAutomator = "2.2.0"
 junit4 = '4.13.2'
-junitJupiter = '5.8.2'
+junitJupiter = '5.9.0'
 kMinRandom = '1.0.4'
 mockk = '1.13.4'
-turbine = '0.7.0'
+turbine = '0.12.1'
 
 coilCompose = '2.3.0'
 


### PR DESCRIPTION
- Bump compile&target sdk versions to 34 for android 14
- Bump min sdk version to 27

### Major Changes:
- Compile&Target sdk version (from `33` to `34`)
    - Release notes: https://developer.android.com/about/versions/14
- Androidx Paging compose (from `1.0.0-alpha18` to `3.2.1`)
    - Release notes: https://developer.android.com/jetpack/androidx/releases/paging#version_32_2

### Minor Changes:
- Kotlin (from `1.8.10` to `1.9.10`)
    - Release notes: https://kotlinlang.org/docs/whatsnew19.html
- Androidx Compose Bom (from `2023.01.00` to `2023.09.00`)
    - Bom mapping: https://developer.android.com/jetpack/compose/bom/bom-mapping
    - Compose Foundation: https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.5.1
    - Compose ui: https://developer.android.com/jetpack/androidx/releases/compose-ui#1.5.1
    - Compose Runtime: https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.5.1
- Androidx Core (from `1.9.0` to `1.12.0`) 
    - Release notes: https://developer.android.com/jetpack/androidx/releases/core#core_and_core-ktx_version_112_2
- Androidx AppCompat (from `1.5.1` to `1.6.1`)
     - Release notes: https://developer.android.com/jetpack/androidx/releases/appcompat#version_161_3
- Androidx Activity Compose (from `1.6.1` to `1.7.2`)
     - Release notes: https://developer.android.com/jetpack/androidx/releases/activity#version_17_2
- Androidx Navigation (from `2.5.3` to `2.7.2`)
     - Release notes: https://developer.android.com/jetpack/androidx/releases/navigation#version_272_3
- Androidx Espresso (from `3.4.0` to `3.5.1`)
     - Release notes: https://developer.android.com/jetpack/androidx/releases/test#espresso-3.5.1
- Dagger (from `2.45` to `2.47`)
     - Release notes: https://github.com/google/dagger/releases/tag/dagger-2.47
     - Compare url: https://github.com/google/dagger/compare/dagger-2.45...dagger-2.47
- Junit Jupiter (from `5.8.2` to `5.9.0`)
     - Release notes: https://junit.org/junit5/docs/5.9.0/release-notes/index.html 
- Turbine (from `0.7.0` to `0.12.1`)
     - Release notes: https://github.com/cashapp/turbine/releases/tag/0.12.1
     - Compare url: https://github.com/cashapp/turbine/compare/0.7.0...0.12.1

### Patch Changes:
- Androidx Lifecycle (from `2.6.0-alpha03` to `2.6.2`)
     - Release notes: https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.2
- Androidx Paging (from `3.2.0-alpha04` to `3.2.1`)
    - Release notes: https://developer.android.com/jetpack/androidx/releases/paging#3.2.1
- Androidx Test Ext (from `1.1.4` to `1.1.5`)
    - Release notes: https://developer.android.com/jetpack/androidx/releases/test#ext.junit-1.1.5
- Androidx Test Ext (from `1.5.1` to `1.5.2`)
    - Release notes: https://developer.android.com/jetpack/androidx/releases/test#runner-1.5.2
    