### PR TITLE
Update gradle properties

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -8,6 +8,8 @@ android {
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")
     }
+
+    buildFeatures.buildConfig = true
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.unsafe.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false


### PR DESCRIPTION
### Changes

- Enable gradle configuration cache
- Do not generate BuildConfig by default, generate it only for network module
- Use R classes with non-final fields by default